### PR TITLE
Add button to remove zero ID items

### DIFF
--- a/Source/MainForm.Designer.cs
+++ b/Source/MainForm.Designer.cs
@@ -127,6 +127,7 @@
             this.reloadItemButton = new DarkUI.Controls.DarkButton();
             this.deleteItemButton = new DarkUI.Controls.DarkButton();
             this.findItemButton = new DarkUI.Controls.DarkButton();
+            this.deleteZeroItemButton = new DarkUI.Controls.DarkButton();
             this.label1 = new DarkUI.Controls.DarkLabel();
             this.forceUseCheckBox = new DarkUI.Controls.DarkCheckBox();
             this.previousPictureBox = new ItemEditor.Controls.ClientItemView();
@@ -1092,16 +1093,26 @@
             this.findItemButton.TabIndex = 40;
             this.findItemButton.Click += new System.EventHandler(this.FindItemButton_Click);
             //
+            // deleteZeroItemButton
+            //
+            this.deleteZeroItemButton.Enabled = false;
+            this.deleteZeroItemButton.Image = global::ItemEditor.Properties.Resources.DeleteIcon;
+            this.deleteZeroItemButton.Location = new System.Drawing.Point(175, 506);
+            this.deleteZeroItemButton.Name = "deleteZeroItemButton";
+            this.deleteZeroItemButton.Size = new System.Drawing.Size(25, 25);
+            this.deleteZeroItemButton.TabIndex = 41;
+            this.deleteZeroItemButton.Click += new System.EventHandler(this.DeleteZeroItemButton_Click);
+            //
             // label1
             //
             this.label1.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
             this.label1.Location = new System.Drawing.Point(134, 509);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(2, 20);
-            this.label1.TabIndex = 41;
-            // 
+            this.label1.TabIndex = 42;
+            //
             // forceUseCheckBox
-            // 
+            //
             this.forceUseCheckBox.AutoSize = true;
             this.forceUseCheckBox.Location = new System.Drawing.Point(14, 162);
             this.forceUseCheckBox.Name = "forceUseCheckBox";
@@ -1222,6 +1233,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(784, 561);
             this.Controls.Add(this.label1);
+            this.Controls.Add(this.deleteZeroItemButton);
             this.Controls.Add(this.findItemButton);
             this.Controls.Add(this.deleteItemButton);
             this.Controls.Add(this.reloadItemButton);
@@ -1368,6 +1380,7 @@
         private DarkUI.Controls.DarkButton reloadItemButton;
         private DarkUI.Controls.DarkButton deleteItemButton;
         private DarkUI.Controls.DarkButton findItemButton;
+        private DarkUI.Controls.DarkButton deleteZeroItemButton;
         private DarkUI.Controls.DarkLabel label1;
         private DarkUI.Controls.DarkComboBox stackOrderComboBox;
         private DarkUI.Controls.DarkLabel stackOrderLabel;

--- a/Source/MainForm.cs
+++ b/Source/MainForm.cs
@@ -189,6 +189,7 @@ namespace ItemEditor
                 this.reloadItemButton.Enabled = true;
                 this.deleteItemButton.Enabled = true;
                 this.findItemButton.Enabled = true;
+                this.deleteZeroItemButton.Enabled = true;
                 this.Loaded = true;
                 this.BuildItemsListBox();
             }
@@ -452,6 +453,7 @@ namespace ItemEditor
             this.reloadItemButton.Enabled = false;
             this.deleteItemButton.Enabled = false;
             this.findItemButton.Enabled = false;
+            this.deleteZeroItemButton.Enabled = false;
             this.Loaded = false;
 
             if (clearLog)
@@ -476,6 +478,7 @@ namespace ItemEditor
             this.toolTip.SetToolTip(this.reloadItemButton, "Reaload Item");
             this.toolTip.SetToolTip(this.deleteItemButton, "Delete Item");
             this.toolTip.SetToolTip(this.findItemButton, "Find Item");
+            this.toolTip.SetToolTip(this.deleteZeroItemButton, "Delete Items with ID 0");
         }
 
         private void BuildItemsListBox()
@@ -1490,6 +1493,28 @@ namespace ItemEditor
         private void DeleteItemButton_Click(object sender, EventArgs e)
         {
             this.DeleteItem(this.CurrentServerItem);
+        }
+
+        private void DeleteZeroItemButton_Click(object sender, EventArgs e)
+        {
+            if (!this.Loaded)
+            {
+                return;
+            }
+
+            List<ServerItem> toDelete = new List<ServerItem>();
+            foreach (ServerItem item in this.ServerItems.Items)
+            {
+                if (item.ID == 0 || item.ClientId == 0)
+                {
+                    toDelete.Add(item);
+                }
+            }
+
+            foreach (ServerItem item in toDelete)
+            {
+                this.DeleteItem(item);
+            }
         }
 
         private void ReloadItemButton_Click(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- add UI button allowing quick deletion of all items whose server or client ID is 0
- wire button into form initialization and tooltip setup
- implement event handler that iterates through items and removes any with ID 0

## Testing
- `./linuxbuild.sh` *(fails: msbuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_689912f2d17483229b9a3d0a61a7cb26