### PR TITLE
Handle optional dat/spr file marker

### DIFF
--- a/Source/Dialogs/PreferencesForm.cs
+++ b/Source/Dialogs/PreferencesForm.cs
@@ -107,7 +107,12 @@ namespace ItemEditor.Dialogs
                 fileStream = new FileStream(fileName, FileMode.Open);
                 using (BinaryReader reader = new BinaryReader(fileStream))
                 {
+                    const uint marker = 0x4F424A4D; // "OBJM"
                     signature = reader.ReadUInt32();
+                    if (signature == marker)
+                    {
+                        signature = reader.ReadUInt32();
+                    }
                 }
             }
             finally

--- a/Source/PluginInterface/Sprite.cs
+++ b/Source/PluginInterface/Sprite.cs
@@ -254,7 +254,12 @@ namespace ItemEditor
             {
                 using (BinaryReader reader = new BinaryReader(fileStream))
                 {
+                    const uint marker = 0x4F424A4D; // "OBJM"
                     uint sprSignature = reader.ReadUInt32();
+                    if (sprSignature == marker)
+                    {
+                        sprSignature = reader.ReadUInt32();
+                    }
                     if (client.SprSignature != sprSignature)
                     {
                         string message = "Bad spr signature. Expected signature is {0:X} and loaded signature is {1:X}.";

--- a/Source/PluginOne/Plugin.cs
+++ b/Source/PluginOne/Plugin.cs
@@ -185,7 +185,12 @@ namespace PluginOne
             using (FileStream fileStream = new FileStream(filename, FileMode.Open))
             {
                 BinaryReader reader = new BinaryReader(fileStream);
+                const uint marker = 0x4F424A4D; // "OBJM"
                 uint datSignature = reader.ReadUInt32();
+                if (datSignature == marker)
+                {
+                    datSignature = reader.ReadUInt32();
+                }
                 if (client.DatSignature != datSignature)
                 {
                     string message = "PluginOne: Bad dat signature. Expected signature is {0:X} and loaded signature is {1:X}.";

--- a/Source/PluginThree/Plugin.cs
+++ b/Source/PluginThree/Plugin.cs
@@ -194,7 +194,12 @@ namespace PluginThree
             {
                 BinaryReader reader = new BinaryReader(fileStream);
 
+                const uint marker = 0x4F424A4D; // "OBJM"
                 uint datSignature = reader.ReadUInt32();
+                if (datSignature == marker)
+                {
+                    datSignature = reader.ReadUInt32();
+                }
                 if (client.DatSignature != datSignature)
                 {
                     string message = "PluginThree: Bad dat signature. Expected signature is {0:X} and loaded signature is {1:X}.";

--- a/Source/PluginTwo/Plugin.cs
+++ b/Source/PluginTwo/Plugin.cs
@@ -187,7 +187,12 @@ namespace PluginTwo
             using (FileStream fileStream = new FileStream(filename, FileMode.Open))
             {
                 BinaryReader reader = new BinaryReader(fileStream);
+                const uint marker = 0x4F424A4D; // "OBJM"
                 uint datSignature = reader.ReadUInt32();
+                if (datSignature == marker)
+                {
+                    datSignature = reader.ReadUInt32();
+                }
                 if (client.DatSignature != datSignature)
                 {
                     string message = "PluginTwo: Bad dat signature. Expected signature is {0:X} and loaded signature is {1:X}.";


### PR DESCRIPTION
## Summary
- allow dat loaders to skip an initial OBJM marker
- ignore optional OBJM marker when loading sprites
- support marker when reading signatures in preferences dialog

## Testing
- `msbuild /p:Configuration=Release ItemEditor.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689d4ac7bb788322ad630a3f930b5dc7