### PR TITLE
Handle optional dat/spr file marker

### DIFF
--- a/Source/Dialogs/PreferencesForm.cs
+++ b/Source/Dialogs/PreferencesForm.cs
@@ -107,7 +107,12 @@ namespace ItemEditor.Dialogs
                 fileStream = new FileStream(fileName, FileMode.Open);
                 using (BinaryReader reader = new BinaryReader(fileStream))
                 {
+                    const uint marker = 0x4F424A4D; // "OBJM"
                     signature = reader.ReadUInt32();
+                    if (signature == marker)
+                    {
+                        signature = reader.ReadUInt32();
+                    }
                 }
             }
             finally

--- a/Source/PluginInterface/Sprite.cs
+++ b/Source/PluginInterface/Sprite.cs
@@ -254,7 +254,14 @@ namespace ItemEditor
             {
                 using (BinaryReader reader = new BinaryReader(fileStream))
                 {
+                    const uint marker = 0x4F424A4D; // "OBJM"
                     uint sprSignature = reader.ReadUInt32();
+                    bool hasMarker = false;
+                    if (sprSignature == marker)
+                    {
+                        sprSignature = reader.ReadUInt32();
+                        hasMarker = true;
+                    }
                     if (client.SprSignature != sprSignature)
                     {
                         string message = "Bad spr signature. Expected signature is {0:X} and loaded signature is {1:X}.";
@@ -283,6 +290,10 @@ namespace ItemEditor
                     foreach (uint element in spriteIndexes)
                     {
                         uint index = element + 3;
+                        if (hasMarker)
+                        {
+                            index += 4;
+                        }
                         reader.BaseStream.Seek(index, SeekOrigin.Begin);
                         ushort size = reader.ReadUInt16();
 

--- a/Source/PluginOne/Plugin.cs
+++ b/Source/PluginOne/Plugin.cs
@@ -185,7 +185,14 @@ namespace PluginOne
             using (FileStream fileStream = new FileStream(filename, FileMode.Open))
             {
                 BinaryReader reader = new BinaryReader(fileStream);
+                const uint marker = 0x4F424A4D; // "OBJM"
                 uint datSignature = reader.ReadUInt32();
+                bool hasMarker = false;
+                if (datSignature == marker)
+                {
+                    datSignature = reader.ReadUInt32();
+                    hasMarker = true;
+                }
                 if (client.DatSignature != datSignature)
                 {
                     string message = "PluginOne: Bad dat signature. Expected signature is {0:X} and loaded signature is {1:X}.";
@@ -195,6 +202,10 @@ namespace PluginOne
 
                 // get max id
                 this.itemCount = reader.ReadUInt16();
+                if (hasMarker)
+                {
+                    this.itemCount = (ushort)(this.itemCount - 2);
+                }
                 reader.ReadUInt16(); // skipping outfits count
                 reader.ReadUInt16(); // skipping effects count
                 reader.ReadUInt16(); // skipping missiles count

--- a/Source/PluginThree/Plugin.cs
+++ b/Source/PluginThree/Plugin.cs
@@ -194,7 +194,14 @@ namespace PluginThree
             {
                 BinaryReader reader = new BinaryReader(fileStream);
 
+                const uint marker = 0x4F424A4D; // "OBJM"
                 uint datSignature = reader.ReadUInt32();
+                bool hasMarker = false;
+                if (datSignature == marker)
+                {
+                    datSignature = reader.ReadUInt32();
+                    hasMarker = true;
+                }
                 if (client.DatSignature != datSignature)
                 {
                     string message = "PluginThree: Bad dat signature. Expected signature is {0:X} and loaded signature is {1:X}.";
@@ -204,6 +211,10 @@ namespace PluginThree
 
                 // get max id
                 this.itemCount = reader.ReadUInt16();
+                if (hasMarker)
+                {
+                    this.itemCount = (ushort)(this.itemCount - 2);
+                }
                 reader.ReadUInt16(); // skipping outfits count
                 reader.ReadUInt16(); // skipping effects count
                 reader.ReadUInt16(); // skipping missiles count

--- a/Source/PluginTwo/Plugin.cs
+++ b/Source/PluginTwo/Plugin.cs
@@ -187,7 +187,14 @@ namespace PluginTwo
             using (FileStream fileStream = new FileStream(filename, FileMode.Open))
             {
                 BinaryReader reader = new BinaryReader(fileStream);
+                const uint marker = 0x4F424A4D; // "OBJM"
                 uint datSignature = reader.ReadUInt32();
+                bool hasMarker = false;
+                if (datSignature == marker)
+                {
+                    datSignature = reader.ReadUInt32();
+                    hasMarker = true;
+                }
                 if (client.DatSignature != datSignature)
                 {
                     string message = "PluginTwo: Bad dat signature. Expected signature is {0:X} and loaded signature is {1:X}.";
@@ -197,6 +204,10 @@ namespace PluginTwo
 
                 // get max id
                 this.itemCount = reader.ReadUInt16();
+                if (hasMarker)
+                {
+                    this.itemCount = (ushort)(this.itemCount - 2);
+                }
                 reader.ReadUInt16(); // skipping outfits count
                 reader.ReadUInt16(); // skipping effects count
                 reader.ReadUInt16(); // skipping missiles count


### PR DESCRIPTION
## Summary
- allow dat loaders to skip an initial OBJM marker
- ignore optional OBJM marker when loading sprites
- support marker when reading signatures in preferences dialog
- adjust item count when marker present to prevent spurious extra IDs

## Testing
- `msbuild /p:Configuration=Release ItemEditor.sln` *(fails: command not found)*
- `dotnet build ItemEditor.sln -c Release` *(fails: command not found)*
- `bash linuxbuild.sh` *(fails: msbuild: command not found; no artifacts copied)*

------
https://chatgpt.com/codex/tasks/task_e_689d4ac7bb788322ad630a3f930b5dc7